### PR TITLE
fix(ci): Switch back to `web-ext submit`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,7 +90,7 @@ jobs:
       - name: Submit to Mozilla
         if: matrix.command == 'Firefox'
         working-directory: ${{ env.DIRECTORY }}-${{ matrix.command }}
-        run: npx web-ext-submit@7
+        run: npx web-ext@7 sign --use-submission-api --channel listed
         env:
           WEB_EXT_API_KEY: ${{ secrets.WEB_EXT_API_KEY }}
           WEB_EXT_API_SECRET: ${{ secrets.WEB_EXT_API_SECRET }}


### PR DESCRIPTION
Related to https://github.com/mozilla/web-ext/issues/804.

It looks like `web-ext-submit` may no longer be needed as per the [comment](https://github.com/mozilla/web-ext/issues/804#issuecomment-1751925100) from the creator of `web-ext-submit`.